### PR TITLE
Measure input validation changes

### DIFF
--- a/fsmpy/__init__.py
+++ b/fsmpy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 """ Includes measure types variables, specifying the type of measure to use in specific measures.
 The types are used to specify a specific measure function proposed in a study.

--- a/fsmpy/distances.py
+++ b/fsmpy/distances.py
@@ -154,8 +154,8 @@ def wang_xin(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet, distance_type
         The distance between the two sets provided.
     """
     check_sets_cardinality(A, B)
-    check_p(p, distance_type, WANGXIN_DISTANCE_2)
-    check_weights(weights, len(A), distance_type, WANGXIN_DISTANCE_1)
+    check_p(p, distance_type, measure_types_required=[WANGXIN_DISTANCE_2])
+    check_weights(weights, len(A), distance_type, measure_types_required=[WANGXIN_DISTANCE_1])
     n = len(A)
 
     m_diff = np.absolute(A.membership_values - B.membership_values)
@@ -235,7 +235,7 @@ def yang_chiclana(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet,  distanc
             "Invalid distance type provided. Please check the available flags.")
 
 
-def grzegorzewski(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet, distance_type: str = DISTANCE_HAMMING) -> np.float64:
+def grzegorzewski(A: FuzzySet, B: FuzzySet, distance_type: str = DISTANCE_HAMMING) -> np.float64:
     """ Distances proposed by P. Grzegorzewski from the related article: 
     "Distances between intuitionistic fuzzy sets and/or interval-valued fuzzy sets based on the Hausdorff metric"
 
@@ -302,7 +302,7 @@ def vlachos_sergiadis(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet) -> n
         arr[valid_indxs] = np.log(arr[valid_indxs])
         return arr
 
-    def iifs(setA: IntuitionisticFuzzySet, setB: IntuitionisticFuzzySet):
+    def iifs(setA: FuzzySet, setB: FuzzySet):
         return np.sum(
             setA.membership_values *
             _log(

--- a/fsmpy/distances.py
+++ b/fsmpy/distances.py
@@ -235,7 +235,7 @@ def yang_chiclana(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet,  distanc
             "Invalid distance type provided. Please check the available flags.")
 
 
-def grzegorzewski(A: FuzzySet, B: FuzzySet, distance_type: str = DISTANCE_HAMMING) -> np.float64:
+def grzegorzewski(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet, distance_type: str = DISTANCE_HAMMING) -> np.float64:
     """ Distances proposed by P. Grzegorzewski from the related article: 
     "Distances between intuitionistic fuzzy sets and/or interval-valued fuzzy sets based on the Hausdorff metric"
 
@@ -302,7 +302,7 @@ def vlachos_sergiadis(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet) -> n
         arr[valid_indxs] = np.log(arr[valid_indxs])
         return arr
 
-    def iifs(setA: FuzzySet, setB: FuzzySet):
+    def iifs(setA: IntuitionisticFuzzySet, setB: IntuitionisticFuzzySet):
         return np.sum(
             setA.membership_values *
             _log(

--- a/fsmpy/sets.py
+++ b/fsmpy/sets.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 import numpy as np
 
 
-class IntuitionisticFuzzySet:
+class FuzzySet:
     """ Object to represent a Fuzzy Sets.
 
     Attributes

--- a/fsmpy/similarities.py
+++ b/fsmpy/similarities.py
@@ -43,7 +43,7 @@ def dengfeng_chuntian(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet, p: i
     """
     check_sets_cardinality(A, B)
     check_p(p)
-    check_weights(weights, len(A))
+    check_weights(weights, len(A), sum_1=True)
 
     fA = (A.membership_values + 1 - A.non_membership_values) / 2.0
     fB = (B.membership_values + 1 - B.non_membership_values) / 2.0
@@ -85,7 +85,7 @@ def liang_shi(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet,  similarity_
     """
     check_sets_cardinality(A, B)
     check_p(p)
-    check_weights(weights, len(A), similarity_type, LIANG_SHI_SIMILARITY_3)
+    check_weights(weights, len(A), actual_measure_type=similarity_type, sum_1=True, measure_types_required=LIANG_SHI_SIMILARITY_3)
 
     if similarity_type == LIANG_SHI_SIMILARITY_3:
         if weights is None:
@@ -261,7 +261,7 @@ def julian_hung_lin(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet, p: int
     """
     check_sets_cardinality(A, B)
     check_p(p)
-    check_weights(weights, len(A))
+    check_weights(weights, len(A), sum_1=True)
 
     if weights is None:
         weights = np.ones(len(A)) / len(A)
@@ -358,7 +358,7 @@ def ye(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet, weights: Iterable =
     if weights is None:
         return 1.0 / n * np.sum(nominator / denominator)
     else:
-        check_weights(weights, len(A))
+        check_weights(weights, len(A), sum_1=True)
         return sum(weights * nominator / denominator)
 
 
@@ -814,7 +814,7 @@ def liu(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet, p: int = 1, weight
     """
     check_sets_cardinality(A, B)
     check_p(p)
-    check_weights(weights, len(A))
+    check_weights(weights, len(A), sum_1=True)
     n = len(A)
 
     if weights is None:
@@ -1159,7 +1159,7 @@ def deng_jiang_fu(A: IntuitionisticFuzzySet, B: IntuitionisticFuzzySet, similari
         The similarity between the two sets provided.
     """
     check_sets_cardinality(A, B)
-    check_p(p, similarity_type, DENG_JIANG_FU_MONOTONIC_TYPE_1_3, DENG_JIANG_FU_MONOTONIC_TYPE_2_3, DENG_JIANG_FU_MONOTONIC_TYPE_3_1, DENG_JIANG_FU_MONOTONIC_TYPE_3_2, DENG_JIANG_FU_MONOTONIC_TYPE_3_3)
+    check_p(p, similarity_type, measure_types_required=[DENG_JIANG_FU_MONOTONIC_TYPE_1_3, DENG_JIANG_FU_MONOTONIC_TYPE_2_3, DENG_JIANG_FU_MONOTONIC_TYPE_3_1, DENG_JIANG_FU_MONOTONIC_TYPE_3_2, DENG_JIANG_FU_MONOTONIC_TYPE_3_3])
 
     if p is not None and similarity_type not in [DENG_JIANG_FU_MONOTONIC_TYPE_1_3, DENG_JIANG_FU_MONOTONIC_TYPE_2_3, DENG_JIANG_FU_MONOTONIC_TYPE_3_1, DENG_JIANG_FU_MONOTONIC_TYPE_3_2, DENG_JIANG_FU_MONOTONIC_TYPE_3_3]:
         warnings.warn("Ignoring parameter p (not used in provided similarity_type).")

--- a/fsmpy/utils/classifiers.py
+++ b/fsmpy/utils/classifiers.py
@@ -113,7 +113,7 @@ class FuzzyTextClassifier(BaseEstimator, ClassifierMixin):
     def fit(self, X: Iterable[IntuitionisticFuzzySet], y: Iterable) -> object:
         """ "Trains" on the X data prpovided.
         
-        Calculates the membership and non-membership values of each word for each unity class in y.
+        Calculates the membership and non-membership values of each word for each unique class in y.
 
         Parameters
         ----------


### PR DESCRIPTION
Added sum_1 parameter to check_weights which indicates if the input weights should have a sum of 1.
Fixed docs for check_weights.

Changed measure_types_required to a list parameter which contains the measure types that are required for check_weights and check_p methods.

Removed validate_subset_sizes. If the membership/non_membership/hesitation degrees aren't equal it will be handled during the measure call instead of affecting the performance due to the checking every time.